### PR TITLE
string to replace now has underscores

### DIFF
--- a/studio/sanity.json
+++ b/studio/sanity.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "api": {
-    "projectId": "SANITY_PROJECT_ID",
+    "projectId": "__SANITY_PROJECT_ID__",
     "dataset": "production"
   },
   "project": {


### PR DESCRIPTION
The API is only looking to replace `__SANITY_PROJECT_ID__` - I've added the extra underscores here

https://github.com/netlify/create-api/blob/f8cec5fcfea73566982bc6c77611a430d1d2d443/src/services/deploy-services/cmss/sanity.js#L302-L305