### PR TITLE
Update env vars for sanity studio & instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,22 +59,16 @@ Sanity Studio code exists for this project in the `studio` directory. First, ins
     cd studio
     npm install
 
-Then run the studio locally.
+Then create a `.env` file in the `studio` directory with the following environment variables and set their values:
 
-    npm start
-
-If you want to see the content, you can open your browser and navigate to localhost:3333.
-
-### Run Sanity Studio
-
-Sanity Studio code exists for this project in the `studio` directory. First, install the dependencies in this directory.
-
-    cd studio
-    npm install
+```plain
+SANITY_STUDIO_PROJECT_ID="..."
+SANITY_STUDIO_DATASET="..."
+```
 
 Then run the studio locally.
 
-    npm start
+    sanity dev
 
 If you want to see the content, you can open your browser and navigate to localhost:3333.
 

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
   name: 'default',
   title: 'Astro Sanity Starter',
 
-  projectId: process.env.SANITY_PROJECT_ID,
-  dataset: process.env.SANITY_DATASET,
+  projectId: process.env.SANITY_STUDIO_PROJECT_ID ?? process.env.SANITY_PROJECT_ID,
+  dataset: process.env.SANITY_STUDIO_DATASET ?? process.env.SANITY_DATASET,
 
   plugins: [structureTool(), visionTool(), markdownSchema()],
 


### PR DESCRIPTION
Changes to instructions for env vars usage, to make sure the template works both when running locally with `stackbit dev` and `sanity dev` and also with the netlify site itself (`netlify dev`).

I've tried applying the same changes to an existing site I had previously deployed from the template and everything seems to work OK.